### PR TITLE
do not traverse Epics that are mistakenly(?) linked to another Epic

### DIFF
--- a/analysis/analisys.go
+++ b/analysis/analisys.go
@@ -1,0 +1,229 @@
+package analysis
+
+import (
+	"strings"
+	"time"
+
+	"io.bytenix.com/jiracsv/jira"
+)
+
+// IssueAnalysis represents the assessment for an epic
+type IssueAnalysis struct {
+	Issue        *jira.Issue
+	Component    *string
+	LinkedIssues struct {
+		Total     int
+		Completed int
+	}
+	StoryPoints struct {
+		Total     int
+		Completed int
+		Complete  bool
+	}
+	NoActivities     bool
+	Impediment       bool
+	MixedTypes       bool
+	IssueNoComponent bool
+	CommentStatus    CheckResultStatus
+	CommentDate      *time.Time
+}
+
+// AnalyzeIssue analyzes a Jira Epic
+func AnalyzeIssue(issue *jira.Issue, component *string) *IssueAnalysis {
+	assessment := &IssueAnalysis{
+		Issue:            issue,
+		Component:        component,
+		Impediment:       false,
+		MixedTypes:       false,
+		IssueNoComponent: false,
+		CommentStatus:    CheckStatusNone,
+	}
+
+	allLinkedIssues := issue.LinkedIssues.FilterByFunction(
+		func(i *jira.Issue) bool {
+			return !i.InStatus(jira.IssueStatusObsolete)
+		},
+	)
+
+	var linkedIssues jira.IssueCollection
+
+	if component != nil && *component != "" {
+		linkedIssues = allLinkedIssues.FilterByFunction(
+			func(i *jira.Issue) bool {
+				return i.HasComponent(*component)
+			},
+		)
+	} else {
+		linkedIssues = allLinkedIssues
+	}
+
+	linkedIssuesDone := linkedIssues.FilterByFunction(
+		func(i *jira.Issue) bool {
+			return i.InStatus(jira.IssueStatusDone)
+		},
+	)
+
+	linkedActivities := linkedIssues.FilterByFunction(
+		func(i *jira.Issue) bool {
+			return i.IsType(jira.IssueTypeStory) || i.IsType(jira.IssueTypeTask)
+		},
+	)
+
+	linkedActivitiesDone := linkedActivities.FilterByFunction(
+		func(i *jira.Issue) bool {
+			return i.InStatus(jira.IssueStatusDone)
+		},
+	)
+
+	assessment.NoActivities = linkedActivities.Len() == 0
+
+	assessment.LinkedIssues.Total = linkedIssues.Len()
+	assessment.LinkedIssues.Completed = linkedIssuesDone.Len()
+
+	assessment.StoryPoints.Total = linkedActivities.StoryPoints()
+	assessment.StoryPoints.Completed = linkedActivitiesDone.StoryPoints()
+
+	assessment.StoryPoints.Complete = true
+
+	for _, i := range allLinkedIssues {
+		if len(i.Fields.Components) == 0 {
+			assessment.IssueNoComponent = true
+		}
+	}
+
+	for _, i := range linkedIssues {
+		if i.IsType(jira.IssueTypeStory) {
+			if !i.HasStoryPoints() {
+				assessment.StoryPoints.Complete = false
+			}
+		} else {
+			assessment.MixedTypes = true
+		}
+
+		if i.Impediment {
+			assessment.Impediment = true
+		}
+	}
+
+	for _, i := range append(linkedIssues, assessment.Issue) {
+		if commentStatus, commentDate := getIssueCommentStatus(i); commentStatus > assessment.CommentStatus {
+			assessment.CommentStatus = commentStatus
+			assessment.CommentDate = commentDate
+		}
+	}
+
+	return assessment
+}
+
+// CheckStatus executes the checks for a specific ReleasePhase
+func (a *IssueAnalysis) CheckStatus() *CheckResult {
+	result := NewCheckResult(true, CheckStatusNone)
+
+	if a.NoActivities {
+		result.SetReady(false).AddMessage("NOSTORIES")
+	}
+
+	if a.Issue.Fields.Description == "" {
+		result.SetReady(false).AddMessage("NODESCRIPTION")
+	}
+
+	if !a.Issue.Approvals.Approved() {
+		result.SetReady(false).AddMessage("NOACKS")
+	}
+
+	if a.Issue.Owner == "" {
+		result.SetReady(false).SetStatus(CheckStatusRed).AddMessage("NODELIVERYOWNER")
+	}
+
+	if a.Issue.QAContact == "" {
+		result.SetReady(false).SetStatus(CheckStatusRed).AddMessage("NOQACONTACT")
+	}
+
+	if a.Issue.Acceptance == "" {
+		result.SetReady(false).SetStatus(CheckStatusRed).AddMessage("NOCRITERIA")
+	}
+
+	if !a.Issue.IsPrioritized() {
+		result.SetReady(false).SetStatus(CheckStatusRed).AddMessage("NOPRIORITY")
+	}
+
+	if !a.Issue.IsActive() && !a.Issue.InStatus(jira.IssueStatusDone) {
+		result.SetStatus(CheckStatusYellow).AddMessage("NOTSTARTED")
+	}
+
+	if !a.StoryPoints.Complete {
+		result.AddMessage("NOSTORYPOINTS")
+	}
+
+	if a.Impediment {
+		result.SetStatus(CheckStatusRed).AddMessage("IMPEDIMENT")
+	}
+
+	if a.Issue.ParentLink == "" {
+		result.SetReady(false).AddMessage("NOINITIATIVE")
+	}
+
+	if a.IssueNoComponent {
+		result.SetReady(false).AddMessage("ISSUENOCOMPONENT")
+	}
+
+	/*
+		for _, i := range linkedIssues {
+			if i.Owner == "" && i.Fields.Sprint.Name != "" {
+				result.AppendCheckResult(CheckStatusNone, CheckStatusYellow, "ISSUENOASSIGNEE")
+			}
+		}
+	*/
+
+	if a.Component != nil {
+		missing := true
+
+		for _, c := range a.Issue.Fields.Components {
+			if c.Name == *a.Component {
+				missing = false
+				break
+			}
+		}
+
+		if missing {
+			result.SetReady(false).SetStatus(CheckStatusYellow).AddMessage("NOCOMPONENT")
+		}
+	}
+
+	if a.Issue.InStatus(jira.IssueStatusDone) {
+		if a.LinkedIssues.Completed != a.LinkedIssues.Total ||
+			a.StoryPoints.Completed != a.StoryPoints.Total {
+			result.SetStatus(CheckStatusRed).AddMessage("NOTDONE")
+		} else {
+			result.SetStatus(CheckStatusGreen)
+		}
+	}
+
+	if a.CommentStatus > CheckStatusNone {
+		result.SetStatus(a.CommentStatus).AddMessage("STATUSCOMMENT")
+	}
+
+	return result
+}
+
+func getIssueCommentStatus(issue *jira.Issue) (CheckResultStatus, *time.Time) {
+	if issue.Fields.Comments == nil {
+		return CheckStatusNone, nil
+	}
+
+	for j := len(issue.Comments) - 1; j >= 0; j-- {
+		if strings.HasPrefix(issue.Comments[j].Body, "GREEN: ") {
+			return CheckStatusGreen, &issue.Comments[j].Updated
+		}
+
+		if strings.HasPrefix(issue.Comments[j].Body, "YELLOW: ") {
+			return CheckStatusYellow, &issue.Comments[j].Updated
+		}
+
+		if strings.HasPrefix(issue.Comments[j].Body, "RED: ") {
+			return CheckStatusRed, &issue.Comments[j].Updated
+		}
+	}
+
+	return CheckStatusNone, nil
+}

--- a/analysis/analisys.go
+++ b/analysis/analisys.go
@@ -50,7 +50,8 @@ func AnalyzeIssue(issue *jira.Issue, component *string) *IssueAnalysis {
 	if component != nil && *component != "" {
 		linkedIssues = allLinkedIssues.FilterByFunction(
 			func(i *jira.Issue) bool {
-				return i.HasComponent(*component)
+				return i.HasComponent(*component) && !i.IsType(jira.IssueTypeEpic)
+
 			},
 		)
 	} else {

--- a/analysis/checks.go
+++ b/analysis/checks.go
@@ -1,0 +1,72 @@
+package analysis
+
+import "strings"
+
+// CheckResultStatus represent the status of a check
+type CheckResultStatus int
+
+const (
+	// CheckStatusNone represent an unknown status
+	CheckStatusNone CheckResultStatus = iota
+
+	// CheckStatusGreen represent no impediment and confidence to deliver in time
+	CheckStatusGreen
+
+	// CheckStatusYellow represents minor impediments that could put at risk the delivery in time
+	CheckStatusYellow
+
+	// CheckStatusRed represents impediments, major roadbloack and the impossibility to deliver in time
+	CheckStatusRed
+)
+
+type CheckResult struct {
+	Ready    bool
+	Status   CheckResultStatus
+	Messages []string
+}
+
+func (s CheckResultStatus) String() string {
+	switch s {
+	case CheckStatusNone:
+		return "NONE"
+	case CheckStatusGreen:
+		return "GREEN"
+	case CheckStatusYellow:
+		return "YELLOW"
+	case CheckStatusRed:
+		return "RED"
+	}
+
+	return "UNKOWN"
+}
+
+// NewCheckResult returns a new CheckResult
+func NewCheckResult(ready bool, status CheckResultStatus) *CheckResult {
+	return &CheckResult{
+		Ready:  ready,
+		Status: status,
+	}
+}
+
+func (r *CheckResult) SetReady(ready bool) *CheckResult {
+	if r.Ready && !ready {
+		r.Ready = false
+	}
+	return r
+}
+
+func (r *CheckResult) SetStatus(status CheckResultStatus) *CheckResult {
+	if status > r.Status {
+		r.Status = status
+	}
+	return r
+}
+
+func (r *CheckResult) AddMessage(message string) *CheckResult {
+	r.Messages = append(r.Messages, message)
+	return r
+}
+
+func (r *CheckResult) MessagesString() string {
+	return strings.Join(r.Messages, ",")
+}

--- a/jira/client.go
+++ b/jira/client.go
@@ -238,7 +238,8 @@ func (c *Client) FindEpics(jql string) (IssueCollection, error) {
 
 	for _, i := range issues {
 		go func(i *Issue, ch chan<- error) {
-			epics, err := c.FindIssues(fmt.Sprintf("\"Epic Link\" = \"%s\"", i.Key))
+			//epics, err := c.FindIssues(fmt.Sprintf("\"Epic Link\" = \"%s\" OR \"Parent Link\" = \"%s\"", i.Key, i.Key))
+			epics, err := c.FindIssues(fmt.Sprintf("issueFunction in issuesInEpics(\"id = %s\") ORDER BY ID ASC", i.Key))
 
 			if err == nil {
 				i.LinkedIssues = epics

--- a/jira/issue.go
+++ b/jira/issue.go
@@ -183,7 +183,7 @@ func (i *Issue) IsPrioritized() bool {
 	return true
 }
 
-// HasStoryPoints returns true if the issue has story points defined
+// HasStoryPoints returns true if the issue has Story Points defined
 func (i *Issue) HasStoryPoints() bool {
 	if i.StoryPoints > NoStoryPoints {
 		return true

--- a/utils.go
+++ b/utils.go
@@ -6,8 +6,10 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"golang.org/x/crypto/ssh/terminal"
+	"io.bytenix.com/jiracsv/analysis"
 	"io.bytenix.com/jiracsv/jira"
 )
 
@@ -68,10 +70,42 @@ func googleSheetMark(value bool) string {
 	return ""
 }
 
+func googleSheetBallot(value bool) string {
+	if value {
+		return "\u2713" // UTF-8 Mark
+	}
+
+	return "\u2717"
+}
+
 func googleSheetProgressBar(value, max int) string {
 	if value > max || (max == 0 && value == 0) {
 		return "\u2014" // UTF-8 Dash
 	}
 
 	return fmt.Sprintf("=SPARKLINE({%d,%d},{\"charttype\",\"bar\";\"color1\",\"#93c47d\";\"color2\",\"#efefef\"})", value, max-value)
+}
+
+func googleSheetStoryPointsBar(value, max int, complete bool) string {
+	if !complete {
+		return "\u2014" // UTF-8 Dash
+	}
+
+	return googleSheetProgressBar(value, max)
+}
+
+func googleSheetCheckStatus(status analysis.CheckResultStatus) string {
+	if status == analysis.CheckStatusNone {
+		return "\u2014" // UTF-8 Dash
+	}
+
+	return status.String()
+}
+
+func googleSheetTime(time *time.Time) string {
+	if time == nil {
+		return "\u2014" // UTF-8 Dash
+	}
+
+	return time.Format("2006-01-02")
 }


### PR DESCRIPTION
Epics should not have Epics as issues. Somehow, my own jira project has
one, which I cannot get rid of (possibly a Jira bug). This patch
silently ignores Epic-in-Epic.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>